### PR TITLE
Allow array of view directories

### DIFF
--- a/lib/express-handlebars.js
+++ b/lib/express-handlebars.js
@@ -188,7 +188,28 @@ ExpressHandlebars.prototype.renderView = function (viewPath, options, callback) 
     // to compute the view's name. Layouts and Partials directories are relative
     // to `settings.view` path
     var view;
-    var viewsPath = options.settings && options.settings.views;
+    // ************************************ ORIGINAL CODE ************************************ //
+    // expects a string for the views path configured in app.set("views", "the_path...")
+    // var viewsPath = options.settings && options.settings.views;
+    // ************************************ ORIGINAL CODE ************************************ //
+    
+    // ************************************ PROPOSED CHANGE ************************************ //
+    // proposed change that allows an array of "views" directories to be passed in to app.set(...)
+    // will loop through the array and the last matching in the array will be used as the directory
+    // order of directories is important
+    var viewsPath = (function (_viewsPath, _viewPath) {
+        // if we have a string for the "views" directory return it
+        if (typeof _viewsPath === 'string') return _viewsPath;
+        var result;
+        var _viewPathDir = _viewPath.substring(0, _viewPath.lastIndexOf('/'));
+        _viewsPath.forEach(dir => {
+            if (dir === _viewPathDir && path.relative(dir, _viewPath).split('.').length > 1) {
+                result = dir;
+            }
+        });
+        return result;
+    })(options.settings && options.settings.views, viewPath);
+    // ************************************ PROPOSED CHANGE ************************************ //
     if (viewsPath) {
         view = this._getTemplateName(path.relative(viewsPath, viewPath));
         this.partialsDir = this.partialsDir || path.join(viewsPath, 'partials/');


### PR DESCRIPTION
Currently express-handlebars allows only a single directory as a string; this change allows an array of view directories. first one found will be used