### PR TITLE
Partials and layouts directories should not rely on instance

### DIFF
--- a/lib/express-handlebars.js
+++ b/lib/express-handlebars.js
@@ -191,8 +191,8 @@ ExpressHandlebars.prototype.renderView = function (viewPath, options, callback) 
 	var viewsPath = options.settings && options.settings.views;
 	if (viewsPath) {
 		view = this._getTemplateName(path.relative(viewsPath, viewPath));
-		this.partialsDir = this.partialsDir || path.join(viewsPath, "partials/");
-		this.layoutsDir = this.layoutsDir || path.join(viewsPath, "layouts/");
+		this.partialsDir = path.join(viewsPath, "partials/");
+		this.layoutsDir = path.join(viewsPath, "layouts/");
 	}
 
 	// Merge render-level and instance-level helpers together.


### PR DESCRIPTION
Hi,

Currently, when changing the `settings.views` using the req.app object does not have an immediate effect. The reason for this that the renderView function checks for previously computed values in the instance. If the views directory has changed but you have a computed value you are stuck.

This simple pull requests fixes that.

Regards