### PR TITLE
Update express-handlebars.js

### DIFF
--- a/lib/express-handlebars.js
+++ b/lib/express-handlebars.js
@@ -226,7 +226,7 @@ ExpressHandlebars.prototype.renderView = function (viewPath, options, callback) 
 				return this.render(
 					layoutPath,
 					utils.assign({}, context, { body: body }),
-					utils.assign({}, options, { layout: undefined }),
+					utils.assign({}, options, { layout: undefined })
 				);
 			}
 


### PR DESCRIPTION
Remove redundant trailing comma in render function parameter list.

This was causing my build to fail in Node 6.5.0.