### PR TITLE
feat: Add partialsDir.rename option

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,7 @@ The string path to the directory where the partials templates reside or object w
 * `dir`: The string path to the directory where the partials templates reside.
 * `namespace`: Optional string namespace to prefix the partial names.
 * `templates`: Optional collection (or promise of a collection) of templates in the form: `{filename: template}`.
+* `rename(filePath, namespace)`: Optional function to rename the partials. Takes two arguments: `filePath`, e.g., `partials/some/path/template.handlebars` and `namespace`.
 
 **Note:** If you configure Express to look for views in a custom location (e.g., `app.set('views', 'some/path/')`), and if your `partialsDir` is not relative to `express settings.view` + `partials/`, you will need to reflect that by passing an updated path as the `partialsDir` property in your configuration.
 

--- a/lib/express-handlebars.js
+++ b/lib/express-handlebars.js
@@ -59,6 +59,7 @@ class ExpressHandlebars {
 			let dirPath;
 			let dirTemplates;
 			let dirNamespace;
+			let dirRename;
 
 			// Support `partialsDir` collection with object entries that contain a
 			// templates promise and a namespace.
@@ -67,6 +68,7 @@ class ExpressHandlebars {
 			} else if (typeof dir === "object") {
 				dirTemplates = dir.templates;
 				dirNamespace = dir.namespace;
+				dirRename = dir.rename;
 				dirPath = dir.dir;
 			}
 
@@ -80,17 +82,21 @@ class ExpressHandlebars {
 			return {
 				templates,
 				namespace: dirNamespace,
+				rename: dirRename,
 			};
 		}));
 
 		const partials = {};
 
 		for (const dir of dirs) {
-			const { templates, namespace } = dir;
+			const { templates, namespace, rename } = dir;
 			const filePaths = Object.keys(templates);
+			
+			const getTemplateNameFn = typeof rename === 'function'
+				? rename : this._getTemplateName.bind(this);
 
 			for (const filePath of filePaths) {
-				const partialName = this._getTemplateName(filePath, namespace);
+				const partialName = getTemplateNameFn(filePath, namespace);
 				partials[partialName] = templates[filePath];
 			}
 		}

--- a/lib/express-handlebars.js
+++ b/lib/express-handlebars.js
@@ -91,9 +91,10 @@ class ExpressHandlebars {
 		for (const dir of dirs) {
 			const { templates, namespace, rename } = dir;
 			const filePaths = Object.keys(templates);
-			
-			const getTemplateNameFn = typeof rename === 'function'
-				? rename : this._getTemplateName.bind(this);
+
+			const getTemplateNameFn = typeof rename === "function"
+				? rename
+				: this._getTemplateName.bind(this);
 
 			for (const filePath of filePaths) {
 				const partialName = getTemplateNameFn(filePath, namespace);

--- a/spec/express-handlebars.test.js
+++ b/spec/express-handlebars.test.js
@@ -71,6 +71,24 @@ describe("express-handlebars", () => {
 			});
 		});
 
+		test("should return renamed partials with rename function", async () => {
+			const fn = jest.fn();
+			const exphbs = expressHandlebars.create({
+				partialsDir: {
+					templates: { "partial/template": fn },
+					namespace: "partial namespace",
+					dir: fixturePath("partials"),
+					rename: (filePath, namespace) => {
+						return `${namespace}/${filePath.split("/")[0]}`;
+					},
+				},
+			});
+			const partials = await exphbs.getPartials();
+			expect(partials).toEqual({
+				"partial namespace/partial": fn,
+			});
+		});
+
 		test("should return partials on path relative to cwd", async () => {
 			const exphbs = expressHandlebars.create({ partialsDir: "spec/fixtures/partials" });
 			const partials = await exphbs.getPartials();


### PR DESCRIPTION
We need more flexibility when it comes to naming partials and don't want to be constrained by our folder structure.

For example, we have

```
/components
    /button
        button.hbs
    /template
        otherTemplate.hbs
```

Currently, this names the partial button/button and template/otherTemplate.

This renaming function allows more flexibility, e.g., naming the two templates button and otherTemplate, ignoring the folder structure.