### PR TITLE
fix: use `context` property for template variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,9 @@ app.set('view engine', 'handlebars');
 
 app.get('/', function (req, res, next) {
     res.render('home', {
-        showTitle: true,
+        context: {
+            showTitle: true,
+        },
 
         // Override `foo` helper only for this rendering.
         helpers: {
@@ -494,13 +496,15 @@ Renders the template at the specified `viewPath` as the `{{{body}}}` within the 
 
 This method is called by Express and is the main entry point into this Express view engine implementation. It adds the concept of a "layout" and delegates rendering to the `render()` method.
 
-The `options` will be used both as the context in which the Handlebars templates are rendered, and to signal this view engine on how it should behave, e.g., `options.cache=false` will _always_ load the templates from disk.
+The `options` will be used to signal this view engine on how it should behave, e.g., `options.cache=false` will _always_ load the templates from disk.
 
 **Parameters:**
 
 * `viewPath`: String path to the Handlebars template file which should serve as the `{{{body}}}` when using a layout.
 
-* `[options]`: Optional object which will serve as the context in which the Handlebars templates are rendered. It may also contain any of the following properties which affect this view engine's behavior:
+* `[options]`: Optional object which will contain any of the following properties which affect this view engine's behavior:
+
+  * `[context]`: The context in which the Handlebars templates are rendered.
 
   * `[cache]`: Whether cached templates can be used if they have already been requested. This is recommended for production to avoid unnecessary file I/O.
 

--- a/examples/advanced/server.js
+++ b/examples/advanced/server.js
@@ -57,23 +57,29 @@ function exposeTemplates (req, res, next) {
 
 app.get("/", function (req, res) {
 	res.render("home", {
-		title: "Home",
+		context: {
+			title: "Home",
+		},
 	});
 });
 
 app.get("/yell", function (req, res) {
 	res.render("yell", {
-		title: "Yell",
+		context: {
+			title: "Yell",
 
-		// This `message` will be transformed by our `yell()` helper.
-		message: "hello world",
+			// This `message` will be transformed by our `yell()` helper.
+			message: "hello world",
+		},
 	});
 });
 
 app.get("/exclaim", function (req, res) {
 	res.render("yell", {
-		title: "Exclaim",
-		message: "hello world",
+		context: {
+			title: "Exclaim",
+			message: "hello world",
+		},
 
 		// This overrides _only_ the default `yell()` helper.
 		helpers: {
@@ -86,8 +92,10 @@ app.get("/exclaim", function (req, res) {
 
 app.get("/echo/:message?", exposeTemplates, function (req, res) {
 	res.render("echo", {
-		title: "Echo",
-		message: req.params.message,
+		context: {
+			title: "Echo",
+			message: req.params.message,
+		},
 
 		// Overrides which layout to use, instead of the defaul "main" layout.
 		layout: "shared-templates",

--- a/lib/express-handlebars.js
+++ b/lib/express-handlebars.js
@@ -181,7 +181,7 @@ class ExpressHandlebars {
 	}
 
 	async renderView (viewPath, options = {}, callback = null) {
-		const context = options;
+		const context = options.context || {};
 
 		let promise;
 		if (!callback) {

--- a/spec/express-handlebars.test.js
+++ b/spec/express-handlebars.test.js
@@ -352,7 +352,7 @@ describe("express-handlebars", () => {
 		test("should render html", async () => {
 			const renderView = expressHandlebars({ defaultLayout: null });
 			const viewPath = fixturePath("render-text.handlebars");
-			const html = await renderView(viewPath, { text: "test text" });
+			const html = await renderView(viewPath, { context: { text: "test text" } });
 			expect(html).toBe("<p>test text</p>");
 		});
 	});
@@ -363,7 +363,7 @@ describe("express-handlebars", () => {
 			const viewPath = fixturePath("render-partial.handlebars");
 			const viewsPath = fixturePath();
 			const html = await exphbs.renderView(viewPath, {
-				text: "test text",
+				context: { text: "test text" },
 				settings: { views: viewsPath },
 			});
 			expect(html.replace(/\r/g, "")).toBe("<body>\n<h1>partial test text</h1>\n<p>test text</p>\n</body>");
@@ -374,7 +374,7 @@ describe("express-handlebars", () => {
 			const viewPath = fixturePath("render-partial.handlebars");
 			const viewsPath = fixturePath();
 			const html = await exphbs.renderView(viewPath, {
-				text: "test text",
+				context: { text: "test text" },
 				settings: { views: [viewsPath] },
 			});
 			expect(html.replace(/\r/g, "")).toBe("<body>\n<h1>partial test text</h1>\n<p>test text</p>\n</body>");
@@ -385,7 +385,7 @@ describe("express-handlebars", () => {
 			const viewPath = fixturePath("render-text.handlebars");
 			const viewsPath = "does-not-exist";
 			const html = await exphbs.renderView(viewPath, {
-				text: "test text",
+				context: { text: "test text" },
 				settings: { views: [viewsPath] },
 			});
 			expect(html).toBe("<p>test text</p>");
@@ -396,13 +396,13 @@ describe("express-handlebars", () => {
 			const viewPath = fixturePath("render-partial.handlebars");
 			const viewsPath = fixturePath();
 			const html = await exphbs.renderView(viewPath, {
-				text: "test text",
+				context: { text: "test text" },
 				settings: { views: viewsPath },
 			});
 			expect(html.replace(/\r/g, "")).toBe("<body>\n<h1>partial test text</h1>\n<p>test text</p>\n</body>");
 			const otherViewsPath = fixturePath("other-views");
 			const otherhtml = await exphbs.renderView(viewPath, {
-				text: "test text",
+				context: { text: "test text" },
 				settings: { views: otherViewsPath },
 			});
 			expect(otherhtml.replace(/\r/g, "")).toBe("<body>\nother layout\n<h1>other partial test text</h1>\n<p>test text</p>\n</body>");
@@ -416,7 +416,7 @@ describe("express-handlebars", () => {
 			const viewPath = fixturePath("render-partial.handlebars");
 			const viewsPath = fixturePath("other-views");
 			const html = await exphbs.renderView(viewPath, {
-				text: "test text",
+				context: { text: "test text" },
 				settings: { views: viewsPath },
 			});
 			expect(html.replace(/\r/g, "")).toBe("<body>\n<h1>partial test text</h1>\n<p>test text</p>\n</body>");
@@ -431,7 +431,7 @@ describe("express-handlebars", () => {
 			});
 			const viewPath = fixturePath("render-helper.handlebars");
 			const html = await exphbs.renderView(viewPath, {
-				text: "test text",
+				context: { text: "test text" },
 				helpers: {
 					help: (text) => text,
 				},
@@ -444,7 +444,7 @@ describe("express-handlebars", () => {
 			const layoutPath = fixturePath("layouts/main.handlebars");
 			const viewPath = fixturePath("render-text.handlebars");
 			const html = await exphbs.renderView(viewPath, {
-				text: "test text",
+				context: { text: "test text" },
 				layout: layoutPath,
 			});
 			expect(html.replace(/\r/g, "")).toBe("<body>\n<p>test text</p>\n</body>");
@@ -453,7 +453,7 @@ describe("express-handlebars", () => {
 		test("should render html", async () => {
 			const exphbs = expressHandlebars.create({ defaultLayout: null });
 			const viewPath = fixturePath("render-text.handlebars");
-			const html = await exphbs.renderView(viewPath, { text: "test text" });
+			const html = await exphbs.renderView(viewPath, { context: { text: "test text" } });
 			expect(html).toBe("<p>test text</p>");
 		});
 
@@ -487,7 +487,7 @@ describe("express-handlebars", () => {
 		test("should call callback with html", (done) => {
 			const exphbs = expressHandlebars.create({ defaultLayout: null });
 			const viewPath = fixturePath("render-text.handlebars");
-			exphbs.renderView(viewPath, { text: "test text" }, (err, html) => {
+			exphbs.renderView(viewPath, { context: { text: "test text" } }, (err, html) => {
 				expect(err).toBe(null);
 				expect(html).toBe("<p>test text</p>");
 				done();


### PR DESCRIPTION
# BREAKING CHANGE:

An object passed to template data will need to be passed as an object in the `context` property.
This prevents mixing untrusted data with express-handlebars options.
For more information see https://blog.shoebpatel.com/2021/01/23/The-Secret-Parameter-LFR-and-Potential-RCE-in-NodeJS-Apps/

Thanks @agustingianni for bringing this to my attention.

**Example:**

```handlebars
<h1>Hi, {{name}}</h1>
```

**<= v5**

```js
res.render('hi', {name: "Tony", layout: false})
```

**v6**

```js
res.render('hi', {context: {name: "Tony"}, layout: false})
```