### PR TITLE
fix handlebars runtime cdn url, fixes #977

### DIFF
--- a/examples/advanced/views/layouts/shared-templates.handlebars
+++ b/examples/advanced/views/layouts/shared-templates.handlebars
@@ -9,7 +9,7 @@
     {{{body}}}
 
     {{! Only needs the Handlebars Runtime, because the exposed templates are precompiled. }}
-    <script src="//cdn.jsdelivr.net/handlebarsjs/4.0.5/handlebars.runtime.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/handlebars@latest/dist/handlebars.js"></script>
     <script>
         (function () {
             var revive    = Handlebars.template,


### PR DESCRIPTION
fixed Handlebars runtime url in echo.js script and set it to https://cdn.jsdelivr.net/npm/handlebars@latest/dist/handlebars.js as in the guide: 
https://handlebarsjs.com/guide/