### PR TITLE
chore: use HTTPS package metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "author": "Eric Ferraiuolo <eferraiuolo@gmail.com> (http://ericf.me/)",
   "repository": {
     "type": "git",
-    "url": "git://github.com/express-handlebars/express-handlebars.git"
+    "url": "https://github.com/express-handlebars/express-handlebars.git"
   },
   "bugs": {
     "url": "https://github.com/express-handlebars/express-handlebars/issues"


### PR DESCRIPTION
Updates package metadata to use HTTPS GitHub URLs instead of legacy unauthenticated URLs.

Validation:
- `git diff --check`
- parsed `package.json` with Node.js